### PR TITLE
Add non-technical starter curriculum and branch blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# BlogCraftAI
+# BlogCraftAI Learning Paths
+
+BlogCraftAI is a structured training program that guides learners from non-technical onboarding to a production-ready AI-assisted blogging platform. This repository currently hosts the **Non-Technical Starter Track** on the main branch, along with blueprints for technical specialization tracks that will live on dedicated branches.
+
+## Repository Structure
+
+- `README.md`: High-level documentation, learning outcomes, and roadmap.
+- `curriculum/non_technical_starter.md`: 30-hour facilitator-ready agenda for non-technical participants.
+- `roadmap/branch_blueprints.md`: Scope documents for future technical branches (Django, Prompt Engineering, Frontend, BlogCraftAI, AI Agents).
+- `resources/`: Curated references, checklists, and templates.
+- `tests/README.md`: Explains the testing strategy for this documentation-focused stage.
+
+## Non-Technical Starter Track Outcomes
+
+Participants completing the 30-hour starter track will be able to:
+
+1. Explain the BlogCraftAI product vision, core features, and stakeholder value.
+2. Map content workflows from ideation to publication, including collaboration touchpoints.
+3. Use provided templates to plan blog campaigns, capture requirements, and assess success metrics.
+4. Identify the technical streams (Django, Prompt Engineering, Frontend, Full Stack, Automation) and understand how each contributes to the full platform.
+5. Assemble a personalized learning and resource plan to transition into one of the technical specialization tracks.
+
+## Required Resources (Main Branch)
+
+- Video conferencing or classroom setup for facilitator-led sessions.
+- Collaborative tools: digital whiteboard (e.g., Miro), shared documents (e.g., Google Docs/Notion).
+- Printed or digital copies of the agenda, worksheets, and checklist templates located in `resources/`.
+- Access to example blog posts, analytics snapshots, and personas to support hands-on activities.
+
+## Technical Track Blueprints
+
+Detailed curricula for the technical branches are prepared in `roadmap/branch_blueprints.md`. These blueprints outline:
+
+- Learning objectives and prerequisites.
+- Required tooling and environment setup.
+- Milestone projects and assessment checkpoints.
+- Testing and documentation expectations.
+
+## Getting Started (Main Branch)
+
+1. Review the 30-hour agenda in `curriculum/non_technical_starter.md`.
+2. Gather the listed resources and configure the collaboration workspace before the first session.
+3. Follow the facilitator checklist for each module to keep participants engaged and on schedule.
+4. Capture learner feedback using the provided survey template to inform improvements before launching the technical tracks.
+
+## Next Steps
+
+- Once the main branch onboarding is complete, create the technical branches following the blueprints in `roadmap/branch_blueprints.md`.
+- Each branch should introduce runnable code, comprehensive tests, and documentation adhering to the program-wide standards outlined here.
+- Update this README with additional outcomes as branches graduate from planning to implementation.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/curriculum/non_technical_starter.md
+++ b/curriculum/non_technical_starter.md
@@ -1,0 +1,134 @@
+# Non-Technical Starter Track (30 Hours)
+
+This facilitator guide equips non-technical stakeholders with the context, language, and collaborative skills to participate in the BlogCraftAI platform build. The curriculum spans **five days (6 hours per day)** with a mix of instruction, workshops, and reflection.
+
+## Audience & Prerequisites
+
+- Content strategists, marketing managers, editors, and project coordinators.
+- Comfort using productivity tools (Google Workspace/Office 365) and virtual collaboration platforms.
+- No coding experience required.
+
+## Learning Objectives
+
+1. Understand the vision, stakeholders, and success metrics for BlogCraftAI.
+2. Master the content lifecycle from ideation to distribution with AI-assisted enhancements.
+3. Translate user stories into requirements that feed the technical teams.
+4. Apply ethical, accessibility, and SEO considerations to every content artifact.
+5. Build a personalized transition plan into a technical specialization track.
+
+## High-Level Agenda
+
+| Day | Theme | Hours | Key Deliverables |
+| --- | ----- | ----- | ---------------- |
+| 1 | Product Vision & Stakeholders | 6 | Value Proposition Canvas, Stakeholder Map |
+| 2 | Content Strategy Foundations | 6 | Editorial Mission Brief, Persona Library |
+| 3 | Workflow & Collaboration | 6 | Content Ops Blueprint, RACI Matrix |
+| 4 | Analytics, Ethics, & Accessibility | 6 | KPI Dashboard Draft, Ethical Use Charter |
+| 5 | Transition Planning & Capstone | 6 | Capstone Presentation, Learning Plan |
+
+## Detailed Schedule
+
+### Day 1 — Product Vision & Stakeholders
+
+| Time | Session | Format | Resources |
+| ---- | ------- | ------ | --------- |
+| 09:00–09:30 | Kickoff & Icebreaker | Facilitated discussion | Slides, participant roster |
+| 09:30–10:30 | Product Vision Deep Dive | Presentation + Q&A | Product brief, demo video |
+| 10:30–11:15 | Stakeholder Mapping Workshop | Small groups | Stakeholder worksheet, personas |
+| 11:15–12:00 | Break & Reflection | Independent | Reflection journal template |
+| 12:00–13:00 | Value Proposition Canvas | Hands-on workshop | Canvas template, sample blogs |
+| 13:00–15:00 | Lunch & Office Hours | Optional | Facilitator support |
+
+**Daily Checkpoint:** Participants submit their value proposition canvases for feedback in the shared workspace.
+
+### Day 2 — Content Strategy Foundations
+
+| Time | Session | Format | Resources |
+| ---- | ------- | ------ | --------- |
+| 09:00–09:20 | Warm-Up & Recap | Standup | Recap cards |
+| 09:20–10:20 | SEO Fundamentals (Non-Technical) | Interactive lecture | Slides, SERP examples |
+| 10:20–11:20 | Persona Development Lab | Group activity | Persona template, analytics snapshots |
+| 11:20–12:00 | Editorial Mission Brief | Workshop | Mission brief template |
+| 12:00–12:30 | Break | Independent | — |
+| 12:30–13:30 | Content Calendar Planning | Collaborative planning | Calendar template, backlog list |
+| 13:30–15:00 | Optional Coaching | Office hours | Facilitator & SME access |
+
+**Daily Checkpoint:** Upload persona dossiers and editorial mission briefs for review.
+
+### Day 3 — Workflow & Collaboration
+
+| Time | Session | Format | Resources |
+| ---- | ------- | ------ | --------- |
+| 09:00–09:30 | Standup & Pain Point Review | Team discussion | Pain point backlog |
+| 09:30–10:45 | Content Lifecycle Mapping | Workshop | Lifecycle diagram template |
+| 10:45–11:30 | Tooling Tour (CMS, DAM, Analytics) | Guided walkthrough | Tool comparison matrix |
+| 11:30–12:00 | Break | Independent | — |
+| 12:00–13:00 | RACI Matrix Exercise | Group work | RACI template |
+| 13:00–14:00 | Collaboration Charter | Facilitated writing | Charter worksheet |
+| 14:00–15:00 | Optional Mentoring | Office hours | Facilitator & SMEs |
+
+**Daily Checkpoint:** Submit finalized workflow map and RACI matrix.
+
+### Day 4 — Analytics, Ethics, & Accessibility
+
+| Time | Session | Format | Resources |
+| ---- | ------- | ------ | --------- |
+| 09:00–09:15 | Daily Standup | Standup | Progress tracker |
+| 09:15–10:15 | Analytics 101 for Content Teams | Demo + discussion | Sample dashboards |
+| 10:15–11:00 | KPI Design Lab | Workshop | KPI worksheet |
+| 11:00–11:30 | Break | Independent | — |
+| 11:30–12:30 | Ethical AI & Editorial Standards | Roundtable | Ethics case studies |
+| 12:30–13:15 | Accessibility Principles (WCAG Overview) | Presentation | Accessibility checklist |
+| 13:15–14:30 | Compliance Action Plan | Group work | Action plan template |
+| 14:30–15:00 | Feedback & Reflection | Retrospective | Feedback form |
+
+**Daily Checkpoint:** Share KPI dashboard draft and ethical use charter for peer feedback.
+
+### Day 5 — Transition Planning & Capstone
+
+| Time | Session | Format | Resources |
+| ---- | ------- | ------ | --------- |
+| 09:00–09:20 | Standup & Week-in-Review | Discussion | Summary slides |
+| 09:20–10:20 | Technical Track Previews | Lightning talks | Track overview cards |
+| 10:20–11:30 | Capstone Sprint | Group work | Capstone brief |
+| 11:30–12:00 | Break | Independent | — |
+| 12:00–13:30 | Capstone Presentations | Presentations + feedback | Presentation rubric |
+| 13:30–14:30 | Individual Learning Plan Workshop | Guided reflection | Learning plan template |
+| 14:30–15:00 | Program Retrospective & Celebration | Group discussion | Celebration kit |
+
+**Final Deliverables:**
+
+- Capstone presentation deck connecting product vision, content workflow, and analytics plan.
+- Individual learning plan selecting a follow-on technical track and required resources.
+
+## Facilitator Toolkit
+
+- **Checklists:** Daily setup, breakout management, and wrap-up checklists (see `resources/checklists.md`).
+- **Communication templates:** Welcome email, daily recap message, and survey invites (`resources/communications.md`).
+- **Assessment rubrics:** Capstone evaluation and participation rubric (`resources/rubrics.md`).
+- **Feedback forms:** Learner survey and instructor reflection notes (`resources/feedback.md`).
+
+## Assessment Strategy
+
+1. **Formative** — Daily checkpoints with facilitator comments in the shared workspace.
+2. **Summative** — Capstone presentation scored with the provided rubric.
+3. **Self-Assessment** — Learner reflection journals reviewed on Day 5.
+4. **Peer Review** — Optional asynchronous peer feedback on deliverables.
+
+## Transition Guidance
+
+- Encourage participants to revisit their learning plans monthly and log progress against milestones.
+- Provide office hours with technical leads from each branch for Q&A before participants choose a specialization.
+- Maintain a shared resource board where alumni can contribute tips, templates, and inspirational case studies.
+
+## Risk Mitigation
+
+- Have backup facilitators for key sessions in case of scheduling conflicts.
+- Preload all templates and decks offline to handle connectivity issues.
+- Offer recorded sessions and asynchronous options for participants in different time zones.
+
+## Appendices
+
+- **Appendix A:** Sample completed templates (stored in `templates/` directory).
+- **Appendix B:** Suggested icebreakers and energizers for hybrid cohorts.
+- **Appendix C:** Accessibility accommodations checklist and escalation protocol.

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,11 @@
+# Resource Library
+
+This directory contains supporting materials for the BlogCraftAI Non-Technical Starter Track.
+
+- `checklists.md` — Daily facilitator checklists.
+- `communications.md` — Email and message templates.
+- `feedback.md` — Survey and reflection prompts.
+- `rubrics.md` — Assessment criteria for capstone and participation.
+- `sample_data.md` — Personas, metrics, and backlog snapshots used in exercises.
+
+Add supplementary assets (slide decks, recordings, datasets) as needed. Ensure sensitive information is redacted before distribution.

--- a/resources/checklists.md
+++ b/resources/checklists.md
@@ -1,0 +1,22 @@
+# Facilitator Checklists
+
+## Daily Setup
+- [ ] Review agenda and learning objectives for the day.
+- [ ] Upload session slide decks and worksheets to the shared drive.
+- [ ] Test video conferencing, breakout rooms, and recording tools.
+- [ ] Prepare digital whiteboards with pre-labeled sections.
+- [ ] Confirm accessibility accommodations and assistive technologies are in place.
+
+## Session Delivery
+- [ ] Kick off with recap of previous day and highlight success stories.
+- [ ] Introduce learning outcomes before each module.
+- [ ] Monitor breakout rooms and provide timely coaching.
+- [ ] Capture key insights and decisions in shared notes.
+- [ ] Track time to maintain pacing and schedule buffers.
+
+## Wrap-Up
+- [ ] Summarize achievements and preview next sessions.
+- [ ] Share daily recap message with callouts and reminders.
+- [ ] Collect checkpoint submissions and provide feedback within 24 hours.
+- [ ] Update risk/issues log with mitigations.
+- [ ] Log facilitator reflections for continuous improvement.

--- a/resources/communications.md
+++ b/resources/communications.md
@@ -1,0 +1,35 @@
+# Communication Templates
+
+## Welcome Email
+```
+Subject: Welcome to the BlogCraftAI Starter Track!
+
+Hi {First Name},
+
+We are excited to kick off the BlogCraftAI Non-Technical Starter Track on {Start Date} at {Start Time}. Please review the attached agenda and confirm your participation.
+
+What to prepare:
+- Ensure you have access to the shared drive (link).
+- Complete the pre-course survey.
+- Review the product brief and sample blog posts.
+
+Looking forward to a collaborative week!
+
+Best,
+Facilitation Team
+```
+
+## Daily Recap Message (Slack/Email)
+```
+Subject: Day {#} Highlights — BlogCraftAI Starter Track
+
+Wins: {Top 3 wins}
+Reminders: {Upcoming deadlines}
+Resources: {Links to templates and recordings}
+Feedback Request: {Link}
+```
+
+## Capstone Feedback Form Intro
+```
+Thank you for presenting your capstone! Please rate each criterion using the provided rubric and add qualitative feedback to help the team continue improving.
+```

--- a/resources/feedback.md
+++ b/resources/feedback.md
@@ -1,0 +1,19 @@
+# Feedback Instruments
+
+## Learner Survey (Daily)
+- Rate your confidence in today's topics (1–5).
+- What was the most valuable insight?
+- Where do you need additional support?
+- Accessibility check: Did you experience any barriers today?
+
+## Instructor Reflection
+- What went well?
+- What should change for the next cohort?
+- Outstanding risks or dependencies?
+- Follow-up actions required before next session?
+
+## Capstone Peer Feedback
+- Strengths of the solution.
+- Areas for refinement.
+- Suggested resources or inspiration.
+- Commitment to support teammates post-program.

--- a/resources/rubrics.md
+++ b/resources/rubrics.md
@@ -1,0 +1,27 @@
+# Assessment Rubrics
+
+## Capstone Presentation
+
+| Criterion | Description | Weight | Rating Scale |
+| --------- | ----------- | ------ | ------------ |
+| Vision Alignment | Clearly articulates BlogCraftAI mission, stakeholders, and value | 25% | 1 (Needs Work) – 5 (Exceptional) |
+| Workflow Design | Demonstrates actionable content lifecycle with defined roles | 25% | 1 – 5 |
+| Analytics & Ethics | Integrates KPIs, accessibility, and ethical guidelines | 20% | 1 – 5 |
+| Presentation Quality | Structure, storytelling, time management, and visuals | 15% | 1 – 5 |
+| Collaboration | Evidence of team coordination and shared ownership | 15% | 1 – 5 |
+
+**Scoring Guidance:**
+- 90–100: Ready for transition to technical track.
+- 75–89: Solid foundation; recommend targeted coaching.
+- < 75: Schedule follow-up mentoring before progression.
+
+## Participation Rubric
+
+| Criterion | Expectations |
+| --------- | ------------ |
+| Engagement | Contributes to discussions, asks clarifying questions, supports peers. |
+| Preparedness | Completes pre-work, brings required materials, and meets deadlines. |
+| Reflection | Shares thoughtful insights during retrospectives and journals. |
+| Professionalism | Demonstrates respect, inclusivity, and accountability. |
+
+Each criterion rated on a scale of 1–4 (1 = Rarely, 4 = Consistently). Learners with average <3 receive personalized coaching plans.

--- a/resources/sample_data.md
+++ b/resources/sample_data.md
@@ -1,0 +1,38 @@
+# Sample Data Pack
+
+Use these references to support exercises throughout the starter track.
+
+## Personas
+1. **Avery Chen — Content Strategist**
+   - Goals: Grow organic traffic by 40% YoY, streamline collaboration.
+   - Pain Points: Fragmented tooling, limited visibility into performance.
+   - Preferred Channels: LinkedIn, company blog, thought leadership newsletters.
+2. **Jordan Patel — Freelance Writer**
+   - Goals: Secure consistent assignments, receive actionable feedback.
+   - Pain Points: Unclear briefs, slow payment cycles, limited analytics access.
+   - Preferred Channels: Email, shared project management board.
+
+## Sample Blog Metrics (Quarterly)
+| Metric | Value |
+| ------ | ----- |
+| Sessions | 82,500 |
+| Organic Traffic % | 63% |
+| Newsletter CTR | 4.8% |
+| Conversion Rate | 1.9% |
+
+## Content Backlog Snapshot
+- AI in Editorial Planning (Thought Leadership)
+- Accessibility Checklist for Content Teams (How-To)
+- Interview with Industry Expert on SEO Trends (Interview)
+- Case Study: Scaling Content Production with Automation (Case Study)
+
+## Compliance Guidelines
+- Follow corporate style guide (link placeholder).
+- Ensure every post includes alt text for images and metadata for SEO.
+- Prohibit sharing personally identifiable information in drafts or comments.
+
+## Analytics Glossary
+- **Session:** A single visit to the website within a 30-minute window.
+- **CTR:** Click-through rate; clicks divided by impressions.
+- **Conversion:** Completion of a tracked goal (newsletter signup, demo request, etc.).
+- **Bounce Rate:** Percentage of sessions with a single pageview.

--- a/roadmap/branch_blueprints.md
+++ b/roadmap/branch_blueprints.md
@@ -1,0 +1,160 @@
+# Technical Branch Blueprints
+
+This document outlines the learning paths and implementation expectations for each technical branch. Use these blueprints to set up branches once repository policies allow branching.
+
+## Django Branch
+
+**Branch Name:** `Django`
+
+### Purpose
+Develop the backend foundation for BlogCraftAI, including project scaffolding, authentication, and RESTful APIs.
+
+### Modules & Milestones
+1. **Environment Setup**
+   - Python 3.11, virtualenv/poetry configuration.
+   - Install Django 5, Django REST Framework, psycopg2, and supporting tooling.
+   - Configure `.env` management, secrets rotation, and Docker Compose for local PostgreSQL.
+2. **Project Scaffold**
+   - Create Django project with apps: `accounts`, `blog`, and `api`.
+   - Establish settings modules for local, staging, and production.
+   - Integrate logging, health checks, and environment-based configuration.
+3. **Database Integration**
+   - Connect to PostgreSQL with connection pooling.
+   - Create migrations for `User`, `Post`, and `Comment` models with audit fields.
+   - Add fixtures for demo data and management commands for seeding.
+4. **Admin & Authentication**
+   - Customize Django admin for content curation workflows.
+   - Implement JWT authentication using `djangorestframework-simplejwt` with refresh token rotation.
+   - Add password reset, email verification, and rate limiting.
+5. **API Development**
+   - Build CRUD endpoints for posts and comments with role-based permissions.
+   - Provide pagination, filtering, and search.
+   - Document endpoints with `drf-spectacular` and generate OpenAPI schema.
+6. **Testing & Quality**
+   - Configure pytest, coverage thresholds (90%+), and GitHub Actions workflow.
+   - Include unit, integration, and API contract tests, with fixtures and factories.
+
+### Deliverables
+- Django project aligned with SOLID and clean architecture principles.
+- Comprehensive API documentation and JWT-protected endpoints.
+- Automated test suite covering success, failure, and edge cases (including database outages and token expiry).
+
+## Prompt Engineering Branch
+
+**Branch Name:** `Prompt Engineering`
+
+### Purpose
+Teach prompt design fundamentals and build AI-assisted suggestion APIs using open-source models.
+
+### Modules & Milestones
+1. **Prompt Engineering Foundations**
+   - Role/system prompt patterns, guardrails, schema enforcement.
+   - Compare few-shot vs. zero-shot strategies.
+2. **Model Integration**
+   - Evaluate Hugging Face open-source models (Mistral-7B, Llama 3 variants) for on-device or API deployment.
+   - Implement caching, batching, and token budgeting strategies.
+3. **API Endpoint Implementation**
+   - Add `/api/ai/suggest` endpoint within Django REST Framework.
+   - Support suggestions for titles, outlines, and SEO keywords based on post drafts.
+   - Enforce latency SLAs via async tasks or queueing if necessary.
+4. **Validation & Safety**
+   - JSON schema validation for request/response payloads.
+   - Guardrails for forbidden terms, profanity filters, and domain compliance.
+   - Implement retry logic, timeout handling, and fallback prompts.
+5. **Testing Strategy**
+   - Unit tests with mocked model responses.
+   - Negative tests for schema violations, forbidden terms, and timeout scenarios.
+   - Load tests to measure throughput and concurrency limits.
+
+### Deliverables
+- Production-ready AI suggestion endpoint with safeguards.
+- Prompt library documenting tested patterns and expected outputs.
+- Monitoring hooks for latency, errors, and content policy breaches.
+
+## Frontend Branch
+
+**Branch Name:** `Frontend`
+
+### Purpose
+Build the user-facing experience using Django Templates, Bootstrap 5, and HTMX interactions.
+
+### Modules & Milestones
+1. **Foundation**
+   - Base template with global navigation, alerts, and responsive grid.
+   - WCAG-compliant color palette and typography.
+2. **Auth Experience**
+   - Login and registration pages with inline validation and error handling.
+   - Accessible forms with ARIA attributes, field-level help text, and password strength meter.
+3. **Blog Experience**
+   - Post list with pagination, category filters, and search.
+   - Post detail with comment threads, inline comment creation (HTMX), and moderation cues.
+4. **Editor Enhancements**
+   - Rich text editor (TipTap/Quill) integrated with “Suggest SEO” button leveraging AI endpoint.
+   - Draft autosave, version history, and preview mode.
+5. **Resilience & Performance**
+   - Lazy loading for images, caching strategies, and asset bundling.
+   - Error states (offline mode, 404/500 pages) with friendly messaging.
+6. **Testing & Accessibility**
+   - Component/unit tests (Jest or Django test client), end-to-end tests (Playwright).
+   - Accessibility audits with axe-core and Lighthouse (90+ scores).
+
+### Deliverables
+- Production-grade frontend aligned with UX best practices.
+- Comprehensive Storybook or pattern library for shared components.
+- Automated tests covering UI flows, accessibility, and responsiveness.
+
+## BlogCraftAI Branch
+
+**Branch Name:** `BlogCraftAI`
+
+### Purpose
+Deliver the complete application by integrating backend, frontend, AI, and deployment pipelines.
+
+### Modules & Milestones
+1. **Architecture & Tooling**
+   - Django 5 + DRF backend with modular app structure.
+   - PostgreSQL via psycopg2, connection pooling, and migrations.
+   - HTMX-enhanced Django templates with progressive enhancement.
+2. **AI Integration**
+   - Hugging Face Transformers (Mistral-7B / Llama 3) for suggestions.
+   - Sentence-transformers for similarity search and recommendations.
+3. **Security & Auth**
+   - JWT authentication, refresh flow, optional social login.
+   - Role-based permissions (admin, editor, contributor, reader).
+4. **Operations**
+   - Production configuration for Render.com with Gunicorn + WhiteNoise.
+   - CI/CD on GitHub, infrastructure-as-code templates, monitoring dashboards.
+5. **Documentation & Testing**
+   - drf-spectacular OpenAPI docs, README updates, architectural decision records.
+   - pytest suite spanning unit, integration, and E2E tests with coverage reports.
+
+### Deliverables
+- Deployment-ready BlogCraftAI platform.
+- Operations handbook including runbooks, scaling strategies, and incident response.
+- Benchmarked performance metrics meeting PageSpeed/Lighthouse targets.
+
+## AI Agents Branch
+
+**Branch Name:** `AI Agents`
+
+### Purpose
+Introduce automation platforms (n8n, Make.com) to orchestrate workflows between BlogCraftAI and external systems.
+
+### Modules & Milestones
+1. **Automation Foundations**
+   - Compare n8n vs. Make.com, establish evaluation criteria.
+   - Security, governance, and data privacy considerations.
+2. **Workflow Design**
+   - Build integrations for content ingestion, publishing, and notifications.
+   - Error handling, retries, and audit logging across nodes.
+3. **Deployment & Monitoring**
+   - Self-hosted n8n configuration, webhook security, and credential vaulting.
+   - Usage dashboards, SLA metrics, and alerting strategies.
+4. **Testing & Documentation**
+   - Simulation scripts for API timeouts, malformed payloads, and rate limiting.
+   - Runbooks for operators and knowledge base for content teams.
+
+### Deliverables
+- Automation playbook with reusable workflow templates.
+- Test harness demonstrating resilience against upstream/downstream failures.
+- Governance model for scaling automation within the organization.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,12 @@
+# Template Library
+
+Use these templates during the starter track workshops. Duplicate the files for each team and store completed versions in the cohort workspace.
+
+- `value_proposition_canvas.md`
+- `editorial_mission_brief.md`
+- `content_ops_blueprint.md`
+- `kpi_dashboard_outline.md`
+- `capstone_brief.md`
+- `learning_plan.md`
+
+Feel free to extend the library with additional templates as new needs arise. Maintain consistent formatting for ease of use.

--- a/templates/capstone_brief.md
+++ b/templates/capstone_brief.md
@@ -1,0 +1,35 @@
+# Capstone Brief — BlogCraftAI Starter Track
+
+## Challenge Statement
+Design a strategy for launching BlogCraftAI's editorial program in the first 90 days.
+
+## Requirements
+- Align with BlogCraftAI mission and stakeholder needs.
+- Define a content workflow that integrates AI-assisted suggestions responsibly.
+- Propose KPIs and feedback loops for continuous improvement.
+- Address accessibility, ethics, and governance.
+
+## Deliverables
+1. Presentation deck (10 slides max).
+2. Content workflow diagram.
+3. KPI dashboard outline with targets.
+4. Risk register with mitigations.
+
+## Evaluation Criteria
+Refer to `resources/rubrics.md` for scoring.
+
+## Suggested Team Roles
+- Strategist (vision, messaging)
+- Operations Lead (workflow & tooling)
+- Analytics Lead (metrics)
+- Ethics & Accessibility Advocate
+
+## Timeline
+- Sprint planning: 30 minutes
+- Build: 60 minutes
+- Presentation: 7 minutes + 3 minutes Q&A
+
+## Support Resources
+- Templates in `/templates`
+- Sample data in `/resources`
+- Facilitator office hours: Day 5, 10:45–11:30

--- a/templates/content_ops_blueprint.md
+++ b/templates/content_ops_blueprint.md
@@ -1,0 +1,31 @@
+# Content Operations Blueprint Template
+
+## Workflow Overview
+- Trigger event:
+- Content stages:
+- Tooling per stage:
+
+## Roles & Responsibilities
+| Role | Responsibilities | Backup |
+| ---- | ---------------- | ------ |
+|      |                  |        |
+
+## SLA & Deadlines
+- Draft completion:
+- Review turnaround:
+- Publication window:
+
+## Quality Gates
+- Editorial review checklist:
+- SEO review checklist:
+- Accessibility audit:
+
+## Risk Register
+| Risk | Impact | Likelihood | Mitigation |
+| ---- | ------ | ---------- | ---------- |
+|      |        |            |            |
+
+## Communication Plan
+- Standups & cadence:
+- Reporting channels:
+- Escalation contacts:

--- a/templates/editorial_mission_brief.md
+++ b/templates/editorial_mission_brief.md
@@ -1,0 +1,31 @@
+# Editorial Mission Brief Template
+
+## Mission Statement
+- Our editorial mission is to...
+
+## Audience Overview
+- Priority personas:
+- Core needs:
+
+## Voice & Tone
+- Adjectives that describe our voice:
+- Style guidelines:
+
+## Content Pillars
+1. Pillar 1 — Focus area & desired action
+2. Pillar 2 — Focus area & desired action
+3. Pillar 3 — Focus area & desired action
+
+## Distribution Strategy
+- Primary channels:
+- Syndication partners:
+- Cadence & timing:
+
+## Success Metrics
+- North star metric:
+- Supporting KPIs:
+
+## Governance
+- Approval workflow:
+- Review cadence:
+- Escalation path:

--- a/templates/kpi_dashboard_outline.md
+++ b/templates/kpi_dashboard_outline.md
@@ -1,0 +1,29 @@
+# KPI Dashboard Outline
+
+## Executive Summary
+- Key wins:
+- Areas of concern:
+
+## Traffic Metrics
+| Metric | Target | Actual | Notes |
+| ------ | ------ | ------ | ----- |
+|        |        |        |       |
+
+## Engagement Metrics
+| Metric | Target | Actual | Notes |
+| ------ | ------ | ------ | ----- |
+|        |        |        |       |
+
+## Conversion Metrics
+| Metric | Target | Actual | Notes |
+| ------ | ------ | ------ | ----- |
+|        |        |        |       |
+
+## Accessibility & Compliance
+- Issues detected:
+- Remediation status:
+
+## Action Items
+1. 
+2. 
+3. 

--- a/templates/learning_plan.md
+++ b/templates/learning_plan.md
@@ -1,0 +1,39 @@
+# Individual Learning Plan Template
+
+## Participant Information
+- Name:
+- Role:
+- Cohort:
+
+## Strengths Snapshot
+- Top competencies demonstrated:
+- Feedback highlights:
+
+## Target Specialization
+- Preferred technical branch:
+- Rationale:
+- Required prerequisites:
+
+## 30-60-90 Day Goals
+| Timeline | Goal | Success Criteria | Support Needed |
+| -------- | ---- | ---------------- | -------------- |
+| 30 days |      |                  |                |
+| 60 days |      |                  |                |
+| 90 days |      |                  |                |
+
+## Learning Resources
+- Courses/workshops:
+- Mentors/coaches:
+- Communities of practice:
+
+## Risk & Mitigation Plan
+- Potential blockers:
+- Mitigation strategies:
+
+## Check-In Cadence
+- Frequency:
+- Accountability partner:
+
+## Sign-Off
+- Participant signature/date:
+- Coach signature/date:

--- a/templates/value_proposition_canvas.md
+++ b/templates/value_proposition_canvas.md
@@ -1,0 +1,31 @@
+# Value Proposition Canvas Template
+
+## Customer Segments
+- Primary audience:
+- Secondary audience:
+- Jobs to be done:
+
+## Gains
+- Desired outcomes:
+- Success indicators:
+
+## Pains
+- Obstacles & frustrations:
+- Existing alternatives:
+
+## Products & Services
+- Core offering:
+- Supporting features:
+
+## Gain Creators
+- Differentiators:
+- Delight factors:
+
+## Pain Relievers
+- How BlogCraftAI removes obstacles:
+- Risk mitigations:
+
+## Evidence & Next Steps
+- Assumptions to validate:
+- Metrics to track:
+- Stakeholders to engage:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Tests Directory
+
+The current stage of the project focuses on curriculum and documentation assets for the non-technical starter track. No automated tests are required at this phase because no executable code has been introduced.
+
+When technical branches are created, add the corresponding automated test suites here. Each subdirectory should include:
+- `unit/` for fast-running isolated tests.
+- `integration/` for service and database scenarios.
+- `e2e/` for full workflow validation.
+- A `README.md` describing coverage, tooling, and execution commands.
+
+Maintaining this placeholder ensures the repository structure already accounts for testing expectations and aligns with the program-wide quality standards.


### PR DESCRIPTION
## Summary
- add a comprehensive 30-hour non-technical starter curriculum with agenda, deliverables, and facilitator guidance
- provide resource library and reusable templates to support participant activities
- document the planned technical branches with detailed blueprints for future implementation and note the placeholder testing strategy

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d1195129408328811cfef37063ee26